### PR TITLE
Increase faucet payout 10x to 0.01 ETH per request

### DIFF
--- a/src/pages/api/faucet.ts
+++ b/src/pages/api/faucet.ts
@@ -26,8 +26,8 @@ const novaCidade = defineChain({
   },
 });
 
-const FAUCET_AMOUNT = "0.001"; // ETH per request
-const MIN_FAUCET_BALANCE = parseEther("0.002"); // stop if faucet wallet runs too low
+const FAUCET_AMOUNT = "0.01"; // ETH per request
+const MIN_FAUCET_BALANCE = parseEther("0.02"); // stop if faucet wallet runs too low
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/faucet.tsx
+++ b/src/pages/faucet.tsx
@@ -223,7 +223,7 @@ export default function Faucet() {
                       Request ETH
                     </span>
                     <span className="ml-auto text-[11px] text-gray-600 font-mono">
-                      0.001 ETH / request
+                      0.01 ETH / request
                     </span>
                   </div>
 
@@ -329,7 +329,7 @@ export default function Faucet() {
                               <p className="text-[11px] sm:text-xs text-gray-500 leading-relaxed">
                                 You can request{" "}
                                 <span className="text-gray-400 font-medium">
-                                  0.001 ETH
+                                  0.01 ETH
                                 </span>{" "}
                                 once per hour per address on the Nova Cidade L3
                                 testnet.


### PR DESCRIPTION
Bumps the per-request amount from 0.001 to 0.01 ETH so users get
enough testnet ETH to actually exercise the app, and raises the
minimum faucet wallet balance threshold proportionally.